### PR TITLE
Made the make tests pass to succeed for the first run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ dmem_pattern := FFFFFFFF
 # Paths
 src_dir := ${CURDIR}/riscv_isa_tests/src
 inc_dir := ${CURDIR}/riscv_isa_tests/includes
-bld_dir := ${CURDIR}/riscv_isa_tests/build/
+bld_dir := ${CURDIR}/riscv_isa_tests/build
 
 rtl_inc := ${CURDIR}/src/includes
 rtl_core := ${CURDIR}/src/core
@@ -22,10 +22,10 @@ rtl_primitives := ${CURDIR}/src/core/primitives
 rtl_pipeline := ${CURDIR}/src/pipeline
 rtl_top := ${CURDIR}/src/top
 rtl_tb := ${CURDIR}/src/tb
-rtl_bld_dir := ${CURDIR}/build/
+rtl_bld_dir := ${CURDIR}/build
 
-test_results := $(rtl_bld_dir)test_results.txt
-test_info := $(rtl_bld_dir)test_info
+test_results := $(rtl_bld_dir)/test_results.txt
+test_info := $(rtl_bld_dir)/test_info
 
 # Environment
 CROSS_PREFIX ?= riscv$(XLEN)-unknown-elf-
@@ -91,10 +91,10 @@ ifeq ($(RVM),1)
 tests_list += div divu mulh mulhsu mulhu mul rem remu
 endif
 
-tests_elf := $(addprefix $(bld_dir),$(tests_list:%=%.elf))
-tests_hex := $(addprefix $(bld_dir),$(tests_list:%=%.hex))
-tests_dump := $(addprefix $(bld_dir),$(tests_list:%=%.dump))
-tests_noext := $(addprefix $(bld_dir),$(tests_list))
+tests_elf := $(addprefix $(bld_dir)/,$(tests_list:%=%.elf))
+tests_hex := $(addprefix $(bld_dir)/,$(tests_list:%=%.hex))
+tests_dump := $(addprefix $(bld_dir)/,$(tests_list:%=%.dump))
+tests_noext := $(addprefix $(bld_dir)/,$(tests_list))
 
 
 # Build
@@ -110,7 +110,7 @@ run_vcs: tests build_vcs
 		sc_exit=$$( $(RISCV_READELF) $$i.elf | grep -w "sc_exit" | awk '{ print $$2 }' ) ; \
 		printf "%s.hex\t%s\n" "$$i" "$$sc_exit" >> $(test_info) ; \
 	done ; \
-	$(rtl_bld_dir)simv \
+	$(rtl_bld_dir)/simv \
 	+test_info=$(test_info) \
 	+test_results=$(test_results) \
 	+imem_pattern=$(imem_pattern) \
@@ -170,16 +170,16 @@ $(bld_dir):
 $(rtl_bld_dir):
 	mkdir -p $@
 
-$(bld_dir)%.o: $(src_dir)/%.S | $(bld_dir)
+$(bld_dir)/%.o: $(src_dir)/%.S | $(bld_dir)
 	$(RISCV_GCC) $(CFLAGS) -c $< -o $@
 
-$(bld_dir)%.elf: $(bld_dir)%.o
+$(bld_dir)/%.elf: $(bld_dir)/%.o
 	$(RISCV_GCC) $^ $(LDFLAGS) -o $@
 
-$(bld_dir)%.hex: $(bld_dir)%.elf
+$(bld_dir)/%.hex: $(bld_dir)/%.elf
 	$(RISCV_OBJCOPY) $^ $@
 
-$(bld_dir)%.dump: $(bld_dir)%.elf
+$(bld_dir)/%.dump: $(bld_dir)/%.elf
 	$(RISCV_OBJDUMP) $^ > $@
 
 clean:


### PR DESCRIPTION
Don't know exact reason, but make doesn't like the ending / in directory
in prerequisites and fails the first make tests pass with message that no rule
found for add.hex target. Second make tests run builds all the tests.
Removing ending / from bld_dir solve the problem and make tests builds from the
first run.
Also Makefile endline fixed.