### PR TITLE
Global Pointer initialization and use

### DIFF
--- a/sim/tests/common/crt.S
+++ b/sim/tests/common/crt.S
@@ -24,6 +24,13 @@ machine_trap_entry:
     .align 6
 
 _start:
+    # initialize Global Pointer
+    .option push
+    .option norelax
+1:  auipc   gp, %pcrel_hi(__global_pointer$)
+    addi    gp, gp, %pcrel_lo(1b)
+    .option pop
+
     # clear bss
     la      a1, __BSS_START__
     la      a2, __BSS_END__
@@ -31,8 +38,6 @@ _start:
 3:  sw      zero, 0(a1)
     add     a1, a1, 4
 4:  bne     a1, a2, 3b
-    auipc   gp, %hi(_gp)
-    addi    gp, gp, %lo(_gp)
     la      sp, __C_STACK_TOP__
 
     // Timer init

--- a/sim/tests/common/crt_tcm.S
+++ b/sim/tests/common/crt_tcm.S
@@ -23,25 +23,29 @@ machine_trap_entry:
 
     .align 6
 _start:
-    auipc gp, %hi(_gp)
-    addi  gp, gp, %lo(_gp)
+    # initialize Global Pointer
+    .option push
+    .option norelax
+1:  auipc   gp, %pcrel_hi(__global_pointer$)
+    addi    gp, gp, %pcrel_lo(1b)
+    .option pop
     la    a0, __reloc_start
     la    a1, __TEXT_START__
     la    a2, __DATA_START__
-    beq   a0, a1, 21f
-    j     2f
-1:  lw    a3, 0(a0)
+    beq   a0, a1, 31f
+    j     3f
+2:  lw    a3, 0(a0)
     sw    a3, 0(a1)
     add   a0, a0, 4
     add   a1, a1, 4
-2:  bne   a1, a2, 1b
+3:  bne   a1, a2, 2b
     # clear bss
     la    a2, __BSS_START__
-21: la    a1, __BSS_END__
-    j     4f
-3:  sw    zero, 0(a2)
+31: la    a1, __BSS_END__
+    j     5f
+4:  sw    zero, 0(a2)
     add   a2, a2, 4
-4:  bne   a1, a2, 3b
+5:  bne   a1, a2, 4b
     // init stack
     la    sp, __C_STACK_TOP__
     // init hart0 TLS
@@ -53,17 +57,17 @@ _start:
     // init tdata
     mv    a1, tp
     la    a2, _tdata_end
-    j     6f
-5:  lw    a3, 0(a0)
+    j     7f
+6:  lw    a3, 0(a0)
     sw    a3, 0(a1)
     add   a0, a0, 4
     add   a1, a1, 4
-6:  bne   a0, a2, 5b
+7:  bne   a0, a2, 6b
     // clear tbss
-    j     8f
-7:  sw    zero, 0(a1)
+    j     9f
+8:  sw    zero, 0(a1)
     add   a1, a1, 4
-8:  bne   a1, a4, 7b
+9:  bne   a1, a4, 8b
 
     // Timer init
     li    t0, mtime_ctrl
@@ -79,8 +83,8 @@ _start:
 
     li    a0, 0
     li    a1, 0
-9:  auipc t0, %pcrel_hi(main)
-    jalr  t0, %pcrel_lo(9b)
+10: auipc t0, %pcrel_hi(main)
+    jalr  t0, %pcrel_lo(10b)
     j     sc_exit
 
 trap_entry:

--- a/sim/tests/common/link.ld
+++ b/sim/tests/common/link.ld
@@ -46,7 +46,7 @@ SECTIONS {
   } >RAM
 
   .sdata : {
-    _gp = . + 0x800;
+    __global_pointer$ = . + 0x800;
     *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2) *(.srodata*)
     *(.sdata .sdata.* .gnu.linkonce.s.*)
     . = ALIGN(CL_SIZE);

--- a/sim/tests/common/link_tcm.ld
+++ b/sim/tests/common/link_tcm.ld
@@ -42,7 +42,7 @@ SECTIONS {
   } >TCM AT>RAM
 
   .rodata : {
-    _gp = . + 0x800;
+    __global_pointer$ = . + 0x800;
     *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2) *(.srodata*)
     . = ALIGN(16);
   } >TCM AT>RAM


### PR DESCRIPTION
In some cases of compilation, incorrect code was generated (use of GP before being initialized).

These updates ensure correct code generation as it is aligned with GCC spec about Global Pointer initialization and use (either in link scripts or assembly).