### PR TITLE
TAPC package definition

### DIFF
--- a/src/core.files
+++ b/src/core.files
@@ -12,6 +12,7 @@ pipeline/scr1_pipe_top.sv
 core/primitives/scr1_reset_cells.sv
 core/primitives/scr1_cg.sv
 core/scr1_clk_ctrl.sv
+core/scr1_tapc_pkg.sv
 core/scr1_tapc_shift_reg.sv
 core/scr1_tapc.sv
 core/scr1_tapc_synchronizer.sv

--- a/src/core/scr1_core_top.sv
+++ b/src/core/scr1_core_top.sv
@@ -8,9 +8,10 @@
 `include "scr1_memif.svh"
 
 `ifdef SCR1_DBGC_EN
-`include "scr1_tapc.svh"
 `include "scr1_dm.svh"
 `include "scr1_hdu.svh"
+
+import scr1_tapc_pkg::*;
 `endif // SCR1_DBGC_EN
 
 `ifdef SCR1_IPIC_EN

--- a/src/core/scr1_core_top.sv
+++ b/src/core/scr1_core_top.sv
@@ -10,8 +10,6 @@
 `ifdef SCR1_DBGC_EN
 `include "scr1_dm.svh"
 `include "scr1_hdu.svh"
-
-import scr1_tapc_pkg::*;
 `endif // SCR1_DBGC_EN
 
 `ifdef SCR1_IPIC_EN
@@ -79,6 +77,13 @@ module scr1_core_top #(
     input   logic [`SCR1_DMEM_DWIDTH-1:0]           dmem_rdata,
     input   type_scr1_mem_resp_e                    dmem_resp
 );
+
+//-------------------------------------------------------------------------------
+// package declaration
+//-------------------------------------------------------------------------------
+`ifdef SCR1_DBGC_EN
+import scr1_tapc_pkg::*;
+`endif // SCR1_DBGC_EN
 
 //-------------------------------------------------------------------------------
 // Local signals declaration

--- a/src/core/scr1_tapc.sv
+++ b/src/core/scr1_tapc.sv
@@ -6,8 +6,9 @@
 `include "scr1_arch_description.svh"
 
 `ifdef SCR1_DBGC_EN
-`include "scr1_tapc.svh"
 `include "scr1_dm.svh"
+
+import scr1_tapc_pkg::*;
 
 module scr1_tapc (
     // JTAG signals

--- a/src/core/scr1_tapc.sv
+++ b/src/core/scr1_tapc.sv
@@ -8,8 +8,6 @@
 `ifdef SCR1_DBGC_EN
 `include "scr1_dm.svh"
 
-import scr1_tapc_pkg::*;
-
 module scr1_tapc (
     // JTAG signals
     input   logic                                   trst_n,         // Test Reset (TRSTn)
@@ -31,6 +29,11 @@ module scr1_tapc (
     output  logic                                   dmi_ch_tdi,     // DMI Chain TDI
     input   logic                                   dmi_ch_tdo      // DMI Chain TDO
 );
+
+//-------------------------------------------------------------------------------
+// package declaration
+//-------------------------------------------------------------------------------
+import scr1_tapc_pkg::*;
 
 //======================================================================================================================
 // Local Parameters

--- a/src/core/scr1_tapc_pkg.sv
+++ b/src/core/scr1_tapc_pkg.sv
@@ -1,7 +1,5 @@
-`ifndef SCR1_INCLUDE_TAPC_DEFS
-`define SCR1_INCLUDE_TAPC_DEFS
 /// Copyright by Syntacore LLC © 2016-2019. See LICENSE for details
-/// @file       <scr1_tapc.svh>
+/// @file       <scr1_tap_pkg.sv>
 /// @brief      TAPC header file
 ///
 
@@ -58,7 +56,4 @@ typedef enum logic [SCR1_TAP_INSTRUCTION_WIDTH - 1:0] {
 
 endpackage : scr1_tapc_pkg
 
-import scr1_tapc_pkg::*;
-
 `endif // SCR1_DBGC_EN
-`endif // SCR1_INCLUDE_TAPC_DEFS

--- a/src/core/scr1_tapc_synchronizer.sv
+++ b/src/core/scr1_tapc_synchronizer.sv
@@ -6,8 +6,9 @@
 `include "scr1_arch_description.svh"
 
 `ifdef SCR1_DBGC_EN
-`include "scr1_tapc.svh"
 `include "scr1_dm.svh"
+
+import scr1_tapc_pkg::*;
 
 module scr1_tapc_synchronizer (
     // System common signals

--- a/src/core/scr1_tapc_synchronizer.sv
+++ b/src/core/scr1_tapc_synchronizer.sv
@@ -8,8 +8,6 @@
 `ifdef SCR1_DBGC_EN
 `include "scr1_dm.svh"
 
-import scr1_tapc_pkg::*;
-
 module scr1_tapc_synchronizer (
     // System common signals
     input   logic                                   pwrup_rst_n,        // Power-Up Reset
@@ -44,6 +42,11 @@ module scr1_tapc_synchronizer (
     output logic                                    dmi_ch_tdo,         // DMI Chain TDO output (TCK domain)
     input  logic                                    dmi_ch_tdo_core     // DMI Chain TDO input  (SysCLK domain)
 );
+
+//-------------------------------------------------------------------------------
+// package declaration
+//-------------------------------------------------------------------------------
+import scr1_tapc_pkg::*;
 
 //-------------------------------------------------------------------------------
 // Local signals declaration


### PR DESCRIPTION
Hi,

In our implementation flow, we are using some RTL Linting tools.
It highlights a potential problem in the TAPC package declaration and use:

ERROR:   Entity scr1_tapc_pkg is defined twice in the same language: in scr1_core_top.sv and scr1_tapc_synchronizer.sv. This may cause unpredictable behaviour.
ERROR:   Entity scr1_tapc_pkg is defined twice in the same language: in scr1_tapc_synchronizer.sv and scr1_tapc.sv. This may cause unpredictable behaviour.

After having a look to SystemVerilog LRM, package declaration has been moved to a design file and import command has been removed from it.
Then include file call in all files using it have been replaced by import command at the right place.

Best regards,
Pascal.



