### PR TITLE
Explicitly pass Zicsr and Zifencei extensions

### DIFF
--- a/sim/tests/common/common.mk
+++ b/sim/tests/common/common.mk
@@ -4,7 +4,7 @@ FLAGS = -O2 -funroll-loops -fpeel-loops -fgcse-sm -fgcse-las $(ADD_FLAGS)
 FLAGS_STR = "$(FLAGS)"
 
 CFLAGS_COMMON = -static -std=gnu99 -fno-common -fno-builtin-printf -DTCM=$(TCM)
-CFLAGS_ARCH = -Wa,-march=rv32$(ARCH) -march=rv32$(ARCH) -mabi=$(ABI)
+CFLAGS_ARCH = -Wa,-march=rv32$(ARCH)_zicsr_zifencei -march=rv32$(ARCH)_zicsr_zifencei -mabi=$(ABI)
 
 CFLAGS := $(FLAGS) $(EXT_CFLAGS) \
 $(CFLAGS_COMMON) \
@@ -12,7 +12,7 @@ $(CFLAGS_ARCH) \
 -DFLAGS_STR=\"$(FLAGS_STR)\" \
 $(ADD_CFLAGS)
 
-LDFLAGS   ?= -nostartfiles -nostdlib -lc -lgcc -march=rv32$(ARCH) -mabi=$(ABI)
+LDFLAGS   ?= -nostartfiles -nostdlib -lc -lgcc -march=rv32$(ARCH)_zicsr_zifencei -mabi=$(ABI)
 
 ifeq (,$(findstring 0,$(TCM)))
 ld_script ?= $(inc_dir)/link_tcm.ld

--- a/sim/tests/isr_sample/Makefile
+++ b/sim/tests/isr_sample/Makefile
@@ -1,6 +1,6 @@
 src_dir := $(dir $(lastword $(MAKEFILE_LIST)))
 
-LDFLAGS := -nostartfiles -nostdlib -march=rv32$(ARCH) -mabi=$(ABI)
+LDFLAGS := -nostartfiles -nostdlib -march=rv32$(ARCH)_zicsr_zifencei -mabi=$(ABI)
 ADD_ASM_MACRO := -DASM
 
 ifeq ($(IPIC) ,1)

--- a/sim/tests/riscv_arch/Makefile
+++ b/sim/tests/riscv_arch/Makefile
@@ -169,13 +169,13 @@ $(RISCV_GCC) $(CFLAGS) -Drvtest_mtrap_routine=True -Dmhandler -Wa,$(2) $(2) -E $
 done
 endef
 
-$(foreach SRC,$(filtered_i),$(eval $(call compile_template,$(SRC),-march=rv32i)))
-$(foreach SRC,$(filtered_im),$(eval $(call compile_template,$(SRC),-march=rv32im)))
-$(foreach SRC,$(filtered_ic),$(eval $(call compile_template,$(SRC),-march=rv32ic)))
+$(foreach SRC,$(filtered_i),$(eval $(call compile_template,$(SRC),-march=rv32i_zicsr_zifencei)))
+$(foreach SRC,$(filtered_im),$(eval $(call compile_template,$(SRC),-march=rv32im_zicsr_zifencei)))
+$(foreach SRC,$(filtered_ic),$(eval $(call compile_template,$(SRC),-march=rv32ic_zicsr_zifencei)))
 
-$(foreach SRC,$(filtered_e),$(eval $(call compile_template,$(SRC),-march=rv32e)))
-$(foreach SRC,$(filtered_em),$(eval $(call compile_template,$(SRC),-march=rv32em)))
-$(foreach SRC,$(filtered_ec),$(eval $(call compile_template,$(SRC),-march=rv32ec)))
+$(foreach SRC,$(filtered_e),$(eval $(call compile_template,$(SRC),-march=rv32e_zicsr_zifencei)))
+$(foreach SRC,$(filtered_em),$(eval $(call compile_template,$(SRC),-march=rv32em_zicsr_zifencei)))
+$(foreach SRC,$(filtered_ec),$(eval $(call compile_template,$(SRC),-march=rv32ec_zicsr_zifencei)))
 
 log_requested_tgt: $(bld_dir)
 	$(foreach test_name, $(filtered), $(eval $(shell echo arch_$(test_name).hex >> $(bld_dir)/../test_info)))

--- a/sim/tests/riscv_compliance/Makefile
+++ b/sim/tests/riscv_compliance/Makefile
@@ -85,7 +85,7 @@ filtered_imc      := $(filter-out $(cut_list),$(testnames_imc))
 # ARCH_FLAGS := -Wa,-march=rv32im -march=rv32im
 # ARCH_FLAGS_C := -Wa,-march=rv32imc -march=rv32imc
 CFLAGS := -I$(inc_dir) -I$(src_dir) -DASM -mabi=ilp32 -D__riscv_xlen=32 -w
-LDFLAGS := -static -fvisibility=hidden -nostdlib -nostartfiles -T$(inc_dir)/link.ld -march=$(ARCH) -mabi=ilp32
+LDFLAGS := -static -fvisibility=hidden -nostdlib -nostartfiles -T$(inc_dir)/link.ld -march=$(ARCH)_zicsr_zifencei -mabi=ilp32
 GCCVERSIONGT7 := $(shell expr `$(RISCV_GCC) -dumpfullversion | cut -f1 -d'.'` \> 7)
 ifeq "$(GCCVERSIONGT7)" "1"
 	LDFLAGS += -mno-relax
@@ -114,9 +114,9 @@ $(RISCV_GCC) $(CFLAGS) -Wa,$(2) $(2) -E $$test_asm                        \
 done
 endef
 
-$(foreach SRC,$(filtered_i),$(eval $(call compile_template,$(SRC),-march=rv32i)))
-$(foreach SRC,$(filtered_im),$(eval $(call compile_template,$(SRC),-march=rv32im)))
-$(foreach SRC,$(filtered_imc),$(eval $(call compile_template,$(SRC),-march=rv32imc)))
+$(foreach SRC,$(filtered_i),$(eval $(call compile_template,$(SRC),-march=rv32i_zicsr_zifencei)))
+$(foreach SRC,$(filtered_im),$(eval $(call compile_template,$(SRC),-march=rv32im_zicsr_zifencei)))
+$(foreach SRC,$(filtered_imc),$(eval $(call compile_template,$(SRC),-march=rv32imc_zicsr_zifencei)))
 
 
 log_requested_tgt: $(bld_dir)
@@ -150,9 +150,9 @@ ref_data:
 
 cp_asm:
 	mkdir -p $(bld_dir)/compliance_asm
-	$(call preprocessing,$(included_i),-march=rv32i)
-	$(call preprocessing,$(included_im),-march=rv32im)
-	$(call preprocessing,$(included_imc),-march=rv32imc)
+	$(call preprocessing,$(included_i),-march=rv32i_zicsr_zifencei)
+	$(call preprocessing,$(included_im),-march=rv32im_zicsr_zifencei)
+	$(call preprocessing,$(included_imc),-march=rv32imc_zicsr_zifencei)
 
 
 riscv_compliance_tests_dir    := $(if $(RISCV_COMPLIANCE_TESTS), $(RISCV_COMPLIANCE_TESTS), ./undefined)

--- a/sim/tests/riscv_isa/Makefile
+++ b/sim/tests/riscv_isa/Makefile
@@ -17,8 +17,8 @@ test_elf  := $(addprefix $(bld_dir)/,$(test_list:%=%.elf))
 test_hex  := $(addprefix $(bld_dir)/,$(test_list:%=%.hex))
 test_dump := $(addprefix $(bld_dir)/,$(test_list:%=%.dump))
 
-CFLAGS := -I$(inc_dir) -I$(src_dir) -DASM -Wa,-march=rv32$(ARCH) -march=rv32$(ARCH) -mabi=ilp32f -D__riscv_xlen=32
-LDFLAGS := -static -fvisibility=hidden -nostdlib -nostartfiles -T$(inc_dir)/link.ld -march=rv32$(ARCH) -mabi=ilp32f
+CFLAGS := -I$(inc_dir) -I$(src_dir) -DASM -Wa,-march=rv32$(ARCH)_zicsr_zifencei -march=rv32$(ARCH)_zicsr_zifencei -mabi=ilp32f -D__riscv_xlen=32
+LDFLAGS := -static -fvisibility=hidden -nostdlib -nostartfiles -T$(inc_dir)/link.ld -march=rv32$(ARCH)_zicsr_zifencei -mabi=ilp32f
 RISCV_TESTS := $(src_dir)/../../../dependencies/riscv-tests/
 
 VPATH += $(src_dir) $(bld_dir) $(obj_dir) $(RISCV_TESTS)


### PR DESCRIPTION
They are used to be a part of base ISA, but later were split out to dedicated extensions.