### PR TITLE
Added thread pointer register initialization

### DIFF
--- a/sim/tests/common/crt.S
+++ b/sim/tests/common/crt.S
@@ -43,6 +43,12 @@ _start:
     add     a1, a1, 4
 4:  bne     a1, a2, 3b
     la      sp, __C_STACK_TOP__
+    /* init tp */
+    la    a0, _tdata_begin
+    la    a2, _tbss_end
+    sub   a1, a2, a0
+    la    a4, __STACK_START__
+    sub   tp, a4, a1
 
     // Timer init
     li      t0, mtime_ctrl

--- a/sim/tests/common/link.ld
+++ b/sim/tests/common/link.ld
@@ -18,7 +18,7 @@ CL_SIZE = 32;
 SECTIONS {
 
   /* code segment */
-  .text.init 0 : { 
+  .text.init ORIGIN(RAM) : { 
     FILL(0);
     . = 0x100 - 12;
     SIM_EXIT = .;


### PR DESCRIPTION
When changing the RAM address, the register value will be incorrect